### PR TITLE
Added templates for issues & PRs

### DIFF
--- a/.github/issue_template/bug_report.md
+++ b/.github/issue_template/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Description
+<!-- What's broken? -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behaviour
+<!-- What should happen? -->
+
+## Actual Behaviour
+<!-- What actually happens? -->
+
+## Additional Context
+<!-- Logs, screenshots, or anything else relevant -->

--- a/.github/issue_template/feature_request.md
+++ b/.github/issue_template/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an improvement or new feature
+labels: enhancement
+---
+
+## Problem to Solve
+<!-- What need or gap does this address? -->
+
+## Proposed Solution
+<!-- How would you like it to work? -->
+
+## Alternatives Considered
+<!-- Other approaches you thought about -->
+
+## Additional Context
+<!-- Mockups, examples, or related issues -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+<!-- What does this PR do?-->
+
+## Approach & Design Decisions
+<!-- Architectural or implementation choices made, and the tradeoffs considered -->
+
+## Security Considerations
+<!-- How this PR handles sensitive data, auth, input validation, or access control. -->
+
+## Testing
+**What's covered:**
+- [ ] Unit tests
+- [ ] Edge cases (list below)
+
+**Edge cases considered:**
+<!-- e.g. empty inputs, concurrent requests, malformed payloads, expired tokens -->
+
+## Checklist
+- [ ] No secrets or credentials in code
+- [ ] Input validation in place
+- [ ] Error handling covers failure paths
+- [ ] Code is self-documenting or commented where non-obvious
+- [ ] No dead code or debug logs left in
+
+## Notes
+<!-- Known limitations, what would be done differently with more time, follow-up improvements, etc. -->


### PR DESCRIPTION
## Feature: Create Templates for PR & Issues
- Set up templates for PR & Issues in the .github folder
- Two issue templates; one for reported bugs, another for new features

Closes #4  

# Testing:
- No effect for app functionality, will test the templates after this is merged!