### PR TITLE
Created plans migration, ran and tested

### DIFF
--- a/migrations/002_create_plans.sql
+++ b/migrations/002_create_plans.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS plans (
     tfsa_balance DECIMAL(12,2) NOT NULL DEFAULT 0,
     rrsp_balance DECIMAL(12,2) NOT NULL DEFAULT 0,
     fhsa_balance DECIMAL(12,2) NOT NULL DEFAULT 0,
-    contribution_priority VARCHAR(50) CHECK (contribution_priority IN ('tfsa_first', 'balanced', 'rrsp_heavy')),
+    contribution_priority VARCHAR(50) NOT NULL DEFAULT 'tfsa_first' CHECK (contribution_priority IN ('tfsa_first', 'balanced', 'rrsp_heavy')),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/migrations/002_create_plans.sql
+++ b/migrations/002_create_plans.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS plans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL DEFAULT 'My Retirement Plan',
+    current_age INT NOT NULL,
+    retirement_age INT NOT NULL,
+    annual_income DECIMAL(12,2) NOT NULL,
+    current_savings DECIMAL(12,2) NOT NULL,
+    monthly_contributions DECIMAL(12,2) NOT NULL,
+    risk_tolerance VARCHAR(20) NOT NULL CHECK (risk_tolerance IN ('conservative', 'moderate', 'aggressive')),
+    retirement_goal DECIMAL(12,2),
+    tfsa_balance DECIMAL(12,2) NOT NULL DEFAULT 0,
+    rrsp_balance DECIMAL(12,2) NOT NULL DEFAULT 0,
+    fhsa_balance DECIMAL(12,2) NOT NULL DEFAULT 0,
+    contribution_priority VARCHAR(50) CHECK (contribution_priority IN ('tfsa_first', 'balanced', 'rrsp_heavy')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_plans_user_id ON plans(user_id);
+
+CREATE OR REPLACE TRIGGER plans_set_updated_at
+BEFORE UPDATE ON plans
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+COMMIT;


### PR DESCRIPTION
## Summary
Plans table migration added. Model for retirement plans has been established.

## Approach & Design Decisions
- CHECK constraints on risk_tolerance and contribution_priority, enforcing valid enum values at DB level
- ON DELETE CASCADE on user_id. Deleting a user deletes plans associated with that user
- DEFAULT 0 on account balances
- set_updated_at() trigger reused from users migration
- index on user_id since all plans filter by user

## Security Considerations
- user_id foreign key enforces referential integrity at DB level
- CHECK constraints prevent invalid data from being inserted

## Related Issues
Closes #12 

## Testing
**What's covered:**
- [ ] Unit tests
- [ ] Edge cases (list below)

**Edge cases considered:**

## Checklist
- [ ] No secrets or credentials in code
- [ ] Input validation in place
- [ ] Error handling covers failure paths
- [ ] Code is self-documenting or commented where non-obvious
- [ ] No dead code or debug logs left in

## Notes
<!-- Known limitations, what would be done differently with more time, follow-up improvements, etc. -->