### PR TITLE
Retirement Goal PUT Validation Update

### DIFF
--- a/src/services/plans.ts
+++ b/src/services/plans.ts
@@ -82,8 +82,11 @@ export const updatePlan = async (
         monthly_contributions:
             data.monthly_contributions ?? parseFloat(existing.monthly_contributions),
         retirement_goal:
-            data.retirement_goal ??
-            (existing.retirement_goal !== null ? parseFloat(existing.retirement_goal) : undefined),
+            'retirement_goal' in data
+                ? (data.retirement_goal ?? null)
+                : existing.retirement_goal !== null
+                  ? parseFloat(existing.retirement_goal)
+                  : null,
         tfsa_balance: data.tfsa_balance ?? parseFloat(existing.tfsa_balance),
         rrsp_balance: data.rrsp_balance ?? parseFloat(existing.rrsp_balance),
         fhsa_balance: data.fhsa_balance ?? parseFloat(existing.fhsa_balance),
@@ -103,7 +106,11 @@ export const updatePlan = async (
     if (accountTotal > merged.current_savings) {
         throw new AppError('Sum of account balances cannot exceed total current savings', 422);
     }
-    if (merged.retirement_goal !== undefined && merged.retirement_goal < merged.current_savings) {
+    if (
+        merged.retirement_goal !== null &&
+        merged.retirement_goal !== undefined &&
+        merged.retirement_goal < merged.current_savings
+    ) {
         throw new AppError('Retirement goal should be greater than current savings', 422);
     }
 
@@ -115,6 +122,7 @@ export const updatePlan = async (
     for (const [col, value] of Object.entries(data)) {
         if (value === undefined || !ALLOWED_UPDATE_COLUMNS.has(col)) continue;
         setClauses.push(`${col} = $${idx}`);
+        // null is a valid value (explicitly clears a nullable column)
         values.push(value);
         idx++;
     }

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -39,7 +39,7 @@ export const planBaseSchema = z.object({
     risk_tolerance: z.enum(['conservative', 'moderate', 'aggressive'], {
         error: 'Invalid risk tolerance',
     }),
-    retirement_goal: z.number().positive('Retirement goal must be positive').optional(),
+    retirement_goal: z.number().positive('Retirement goal must be positive').nullable().optional(),
     tfsa_balance: z.number().min(0, 'TFSA balance cannot be negative'),
     rrsp_balance: z.number().min(0, 'RRSP balance cannot be negative'),
     fhsa_balance: z.number().min(0, 'FHSA balance cannot be negative'),
@@ -80,7 +80,7 @@ export const createPlanSchema = planBaseSchema.superRefine((data, ctx) => {
     }
 
     // Retirement goal vs. current savings
-    if (data.retirement_goal !== undefined && data.retirement_goal < data.current_savings) {
+    if (data.retirement_goal != null && data.retirement_goal < data.current_savings) {
         ctx.addIssue({
             code: 'custom',
             message: 'Retirement goal should be greater than current savings',


### PR DESCRIPTION
## Summary
Fixed a bug where on form submission, clearing retirement goal on existing plan would preserve old value silently.

## Approach & Design Decisions

## Security Considerations
<!-- How this PR handles sensitive data, auth, input validation, or access control. -->

## Related Issues
<!-- What issue does this PR close? -->

## Testing
**What's covered:**
- [ ] Unit tests
- [ ] Edge cases (list below)

**Edge cases considered:**
- Edit plan with existing retirement goal, clear the field leads to DB storing null
- Edit plan without touching retirement goal keeps the existing value preserved
- Set retirement goal below current savings returns 422 validation error

## Checklist
- [ ] No secrets or credentials in code
- [ ] Input validation in place
- [ ] Error handling covers failure paths
- [ ] Code is self-documenting or commented where non-obvious
- [ ] No dead code or debug logs left in

## Notes
<!-- Known limitations, what would be done differently with more time, follow-up improvements, etc. -->