### PR TITLE
migration complete

### DIFF
--- a/migrations/003_create_chat_messages.sql
+++ b/migrations/003_create_chat_messages.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS chat_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    plan_id UUID NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
+    role VARCHAR(10) NOT NULL CHECK (role IN ('user', 'assistant')),
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_plan_id ON chat_messages(plan_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Adds the chat_messages migration file for upcoming Anthropic API integration.

## Approach & Design Decisions
- ON DELETE CASCADE for plan_id: deleting a plan removes chat history
- CHECK (role IN ('user', 'assistant')) enforces valid message roles at DB level
- No updated_at since messages are immutable once created
- Index on plan_id since all chats are filtered by plan

## Security Considerations
- Foreign key to plans ensures chat messages are associated with a plan

## Related Issues
Closes #15 

## Testing
**What's covered:**
- [ ] Unit tests
- [x] Edge cases (list below)

**Edge cases considered:**
- IF NOT EXISTS allows migration to be ran multiple times
- Verified table and index exists after migration is ran

## Checklist
- [x] No secrets or credentials in code
- [x] Input validation in place
- [x] Error handling covers failure paths
- [x] Code is self-documenting or commented where non-obvious
- [x] No dead code or debug logs left in

## Notes
- Chat history is per-plan
- No conversation summarization or cleanup logic (not ideal for production, but archival for long histories is out of scope for this project)